### PR TITLE
Preserve the error message on non-zero exit codes

### DIFF
--- a/code/queue.rb
+++ b/code/queue.rb
@@ -1441,7 +1441,7 @@ module RQ
         completion = [nil, nil, nil]
       end
 
-      if exit_status != 0
+      if exit_status != 0 && completion[1] != :err
         write_msg_status(msg_id, "PROCESS EXITED IMPROPERLY - MOVING TO ERR - Completion was #{completion[1]} but exit status was #{exit_status}" )
         new_state = 'err'
       elsif [:done, :relayed, :resend, :err].include? completion[1]


### PR DESCRIPTION
I propose this based on the following results:

Example 1
```
write_status "err" "the system is down"
exit 0
```
```
status	: 	err - the system is down
state	: 	err
```

Example 2
```
write_status "err" "the system is down"
exit 1
```
```
status	: 	err - PROCESS EXITED IMPROPERLY - MOVING TO ERR - Completion was err but exit status was pid 8675 exit 1
state	: 	err
```