### PR TITLE
Include message lists in the json response for a queue.

### DIFF
--- a/code/views/queue_json.erb
+++ b/code/views/queue_json.erb
@@ -10,10 +10,10 @@
 ,"err_size":<%= num_messages['err'] -%>
 ,"relayed_size":<%= num_messages['relayed'] -%>
 ,"messages":{
-"prep":<%= qc.messages({'state' => 'prep', 'limit' => 50}).to_json %>,
+"prep":<%= qc.messages({'state' => 'prep'}).to_json %>,
 "que":<%= qc.messages({'state' => 'que'}).to_json %>,
 "run":<%= qc.messages({'state' => 'run'}).to_json %>,
-"done":<%= qc.messages({'state' => 'done', 'limit' => 50}).to_json %>,
+"done":<%= qc.messages({'state' => 'done'}).to_json %>,
 "err":<%= qc.messages({'state' => 'err'}).to_json %>
 }
 <%- end -%>

--- a/code/views/queue_json.erb
+++ b/code/views/queue_json.erb
@@ -9,5 +9,12 @@
 ,"done_size":<%= num_messages['done'] -%>
 ,"err_size":<%= num_messages['err'] -%>
 ,"relayed_size":<%= num_messages['relayed'] -%>
+,"messages":{
+"prep":<%= qc.messages({'state' => 'prep', 'limit' => 50}).to_json %>,
+"que":<%= qc.messages({'state' => 'que'}).to_json %>,
+"run":<%= qc.messages({'state' => 'run'}).to_json %>,
+"done":<%= qc.messages({'state' => 'done', 'limit' => 50}).to_json %>,
+"err":<%= qc.messages({'state' => 'err'}).to_json %>
+}
 <%- end -%>
 }


### PR DESCRIPTION
Not sure this is complete enough to start implementing live-update of the views but this would be useful for more granular monitoring.

```
$ curl -s http://localhost:3333/q/tester.json | json_pp
{
   "uptime" : 1244,
   "status" : "UP",
   "messages" : {
      "que" : [
         [
            "20150420.2002.22.491.4337777",
            1429560142
         ],
         [
            "20150420.2002.18.641.4337771",
            1429560138
         ]
      ],
      "run" : [
         [
            "20150420.2002.14.602.4337762",
            "que"
         ]
      ],
      "done" : [
         "20150420.1945.53.550.4337060",
         "20150420.1945.40.244.4337048",
         "20150420.1944.12.185.4337011",
         "20150420.1943.51.860.4336990"
      ],
      "err" : [
         "20150420.1943.31.613.4336971"
      ],
      "prep" : []
   },
   "run_size" : 1,
   "que_size" : 2,
   "done_size" : 4,
   "err_size" : 1,
   "prep_size" : 0,
   "relayed_size" : 0
}
```