### PR TITLE
Add a simple filtering search endpoint to RQ

### DIFF
--- a/test/run_tests.sh
+++ b/test/run_tests.sh
@@ -80,6 +80,7 @@ for test in \
    test_web_overrides.rb \
    send_dup.rb \
    test_web_done_json.rb \
+   test_web_search.rb \
    env_var_test.rb ; do
 
       echo "RUNNING TEST: ${test}"

--- a/test/setup_test_queues.sh
+++ b/test/setup_test_queues.sh
@@ -30,6 +30,7 @@ rm -fr queue/test_nop
 rm -fr queue/test_ansi
 rm -fr queue/test_env_var
 rm -fr queue/test_change
+rm -fr queue/test_search
 
 echo "Creating the test queue..."
 curl -0 --cookie-jar ./cookie_jar  http://127.0.0.1:${rq_port}/new_queue -sL -F queue[name]=test -F queue[script]=./test/test_script.sh -F queue[num_workers]=1 -F queue[exec_prefix]="" -o _install_test.txt
@@ -105,6 +106,13 @@ fi
 
 echo "Creating the ansi test queue..."
 curl -0 --cookie-jar ./cookie_jar http://127.0.0.1:${rq_port}/new_queue -sL -F queue[name]=test_ansi -F queue[script]=./test/ansi_script.sh -F queue[num_workers]=1 -F queue[exec_prefix]="" -o _install_ansi_script.txt
+if [ "$?" -ne "0" ]; then
+  echo "Sorry, web server for RQ failed to respond correctly"
+  exit 1
+fi
+
+echo "Creating the search test queue..."
+curl -0 --cookie-jar ./cookie_jar  http://127.0.0.1:${rq_port}/new_queue -sL -F queue[name]=test_search -F queue[script]=./test/test_script.sh -F queue[num_workers]=1 -F queue[exec_prefix]="" -o _install_test.txt
 if [ "$?" -ne "0" ]; then
   echo "Sorry, web server for RQ failed to respond correctly"
   exit 1

--- a/test/test_web_search.rb
+++ b/test/test_web_search.rb
@@ -1,0 +1,87 @@
+#!/usr/bin/env ruby
+$: << File.expand_path('..', File.dirname(__FILE__))
+
+require 'vendor/environment'
+require 'net/http'
+require 'uri'
+require 'fileutils'
+require 'fcntl'
+require 'json'
+require 'test/unit'
+
+class TC_WebSearch < Test::Unit::TestCase
+  def setup
+    @rq_port = (ENV['RQ_PORT'] || 3333).to_i
+    @base_uri = "http://127.0.0.1:#{@rq_port}/search?name=test_search"
+    @param1 = "http://127.0.0.1:#{@rq_port}/search?name=test_search&query[param1]=ear"
+    @empty = "http://127.0.0.1:#{@rq_port}/search?name=test_search&query[fakestuff]=asdfasdf"
+
+    @messages = [
+        { 'dest' => "http://127.0.0.1:#{@rq_port}/q/test_search",
+          'src' => 'test_search',
+          'param1' => 'ear',
+          '_method' => 'prep'
+        },
+        { 'dest' => "http://127.0.0.1:#{@rq_port}/q/test_search",
+          'src' => 'test_search',
+          'param1' => 'hello:pear',
+          '_method' => 'prep'
+        },
+        { 'dest' => "http://127.0.0.1:#{@rq_port}/q/test_search",
+          'src' => 'test_search',
+          'param1' => 'search',
+          '_method' => 'prep'
+        },
+        { 'dest' => "http://127.0.0.1:#{@rq_port}/q/test_search",
+          'src' => 'test_search',
+          'param1' => 'html',
+          '_method' => 'prep'
+        },
+        { 'dest' => "http://127.0.0.1:#{@rq_port}/q/test_search",
+          'src' => 'test_search',
+          'param1' => 'html',
+          '_method' => 'prep'
+        }
+    ]
+    @messages.each do |m|
+      post_new_mesg(m)
+    end
+  end
+
+  def post_new_mesg(mesg)
+    form = { :mesg => mesg.to_json }
+    remote_q_uri = mesg['dest']
+      res = Net::HTTP.post_form(URI.parse(remote_q_uri + "/new_message"), form)
+    assert_equal("200", res.code)
+
+    result = JSON.parse(res.body)
+
+    assert_equal("ok", result[0])
+
+    msg_id = result[1][/\/q\/[^\/]+\/([^\/]+)/, 1]
+    result[1]
+  end
+
+  def test_search_all_urls
+    res = Net::HTTP.get_response(URI.parse(@base_uri))
+
+    assert_equal("200", res.code)
+    assert_equal(@messages.length, JSON.parse(res.body).length)
+
+    res = Net::HTTP.get_response(URI.parse(@param1))
+
+    assert_equal("200", res.code)
+    assert_equal(3, JSON.parse(res.body).length)
+
+    res = Net::HTTP.get_response(URI.parse(@param1+"&exact=true"))
+
+    assert_equal("200", res.code)
+    assert_equal(1, JSON.parse(res.body).length)
+
+
+    res = Net::HTTP.get_response(URI.parse(@empty))
+
+    assert_equal("200", res.code)
+    assert_equal(0, JSON.parse(res.body).length)
+  end
+end


### PR DESCRIPTION
Searches within a single queue for any messages that match a given set of parameters (url-encoded).
For params that don't exist in a message, will return empty.