### PR TITLE
add move_errors.sh and reclone.sh scripts

### DIFF
--- a/bin/move_errors.sh
+++ b/bin/move_errors.sh
@@ -1,0 +1,29 @@
+#!/bin/sh
+# moves all RQ errors into /rq/tmp
+
+BASEDEST=/rq/tmp
+
+if [ ! -d $BASEDEST ]
+then
+  echo "$BASEDEST does not exist"
+  exit 1
+fi
+
+for fullqueue in `find /rq/current/queue/ -maxdepth 1 -not -wholename /rq/current/queue/ -type d`
+do
+  cd $fullqueue/err
+  queue=`basename $fullqueue`
+  DEST=$BASEDEST/$queue
+  mkdir -p $DEST
+  if [ -w $DEST ]
+  then
+    FINALDEST=$DEST
+  else
+    FINALDEST=$BASEDEST
+  fi
+  for i in `find . -maxdepth 1 -not -wholename . -type d`; do
+    echo "moving $i to $FINALDEST/$i"
+    mv $i $FINALDEST
+  done
+done
+

--- a/bin/reclone.sh
+++ b/bin/reclone.sh
@@ -1,0 +1,37 @@
+#!/bin/sh
+
+q=$1
+
+cd /rq/current/config
+host=`sed 's/,/\n/g' config.json | grep host | awk -F: '{print $NF}' | tr -d '\"'`
+echo hostname is $host
+#read junk
+
+cd /rq/current/queue
+
+if [ "x$q" = "x" ] ; then
+        echo "Usage: $0 <queuename>"
+        exit 1
+fi
+
+if [ ! -d $q ] ; then
+        echo "Bad queue name: $q"
+        exit 1
+fi
+
+cd /rq/current/queue/$q/err
+
+c=`ls -1 | wc -l`
+
+if [ $c -lt 1 ] ; then
+        echo "nothing to clone here"
+        exit 0
+fi
+
+mkdir -p /rq/tmp/$q > /dev/null 2>&1
+
+for i in * ; do
+        (cd /rq/current/ ; bin/rq clone --msg_id http://${host}:3333/q/${q}/${i} ) \
+        && mv $i /rq/tmp/${q} || mv $i /rq/tmp/
+done
+


### PR DESCRIPTION
move_errors.sh moves errors from the <queue>/err dir into /rq/tmp
reclone.sh moves the error out of the way and creates a new RQ message in the same RQ with the same arguments as the error