### PR TITLE
remove stale pidfiles after checking for running rq

### DIFF
--- a/bin/rc.rq
+++ b/bin/rc.rq
@@ -39,6 +39,8 @@ start)
 		echo "RQ is already running at pid $RQPID"
 		exit 0
 	fi
+	# remove any pidfile that exists since it's stale
+	rm -f /rq/current/config/queuemgr.pid
 
 	if [ "$NLIMIT" ]; then ulimit -n $NLIMIT; fi
 	sudo -H -u $RQUSER $RQDIR/bin/rq-mgr start


### PR DESCRIPTION
Since we already check for a running rq-mgr process just before, we can assume any remaining pidfiles are stale and can be deleted.

This resolves an issue where the pidfile contains a pid which happens to match a running process, but RQ is not running at all.